### PR TITLE
Fix wrong number display of users without post

### DIFF
--- a/index.php
+++ b/index.php
@@ -248,7 +248,7 @@ if (!empty($school) && !empty($course) && !empty($forum)) {
         }
     }
     $count = count($no_post_users);
-    $countdiff = count($no_post_users) - 10;
+    $countdiff = count($no_post_users) - $i;
     $modal = '
 <div class="modal fade" id="basicModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
     <div class="modal-dialog">


### PR DESCRIPTION
When there was less than 10 users without post the number of other users were incorrect.
